### PR TITLE
Version 1.1.0 bump with Assemble.io

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/app/index.js
+++ b/app/index.js
@@ -106,7 +106,7 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 					return cb(err);
 				}
 
-				remote.directory('helpers.js', 'app/assemble/helpers');
+				remote.directory('.', 'app/assemble/helpers');
 
 				cb();
 			}, true);

--- a/app/index.js
+++ b/app/index.js
@@ -15,7 +15,7 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 
 		// Have Yeoman greet the user.
 		this.log(yosay(
-			'Welcome to the BarkleyREI project generator! Comes with HTML5 Boilerplate, SASS, jQuery (2.x), Modernizr, Foundation, and autoprefixer'
+			'Welcome to the BarkleyREI project generator! Comes with HTML5 Boilerplate, SASS, jQuery (2.x), Assemble.io, Modernizr, Foundation, and autoprefixer.'
 		));
 		var prompts = [{
 			type: 'input',
@@ -52,14 +52,26 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 	writing: {
 		app: function () {
 			this.dest.mkdir('app');
+			// Assemble
+			this.dest.mkdir('app/assemble');
+			// Assembled HTML
 			this.dest.mkdir('app/modules');
+			// Compiled CSS
 			this.dest.mkdir('app/css');
+			// Your scripts
 			this.dest.mkdir('app/js');
+			this.dest.mkdir('app/js/plugins');
+			this.dest.mkdir('app/js/modules');
+			this.dest.mkdir('app/js/lib');
+
+			this.template('.gitkeep', 'app/js');
+			this.template('.gitkeep', 'app/js/plugins');
+			this.template('.gitkeep', 'app/js/modules');
+			this.template('.gitkeep', 'app/js/lib');
+			// Images
 			this.dest.mkdir('app/img');
 
 			this.src.copy('rocket.png', 'app/img/rocket.png');
-
-			this.dest.mkdir('app/plugins');
 
 			this.template('_package.json', 'package.json');
 			this.template('_bower.json', 'bower.json');
@@ -68,8 +80,34 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 		},
 
 		html: function () {
-			this.template('index.html', 'app/index.html');
-			this.template('template.html', 'app/template.html');
+			// this.template('index.html', 'app/index.html');
+			// this.template('template.html', 'app/template.html');
+		},
+
+		assemble: function () {
+			var cb = this.async();
+
+			// Directory Structure
+			this.remote('BarkleyREI', 'brei-assemble-structure', 'master', function (err, remote) {
+				if (err) {
+					return cb(err);
+				}
+
+				remote.directory('.', 'app/assemble');
+
+				cb();
+			}, true);
+
+			// Helpers
+			this.remote('BarkleyREI', 'brei-assemble-helpers', 'master', function (err, remote) {
+				if (err) {
+					return cb(err);
+				}
+
+				remote.directory('helpers.js', 'app/assemble/helpers');
+
+				cb();
+			}, true);
 		},
 
 		sass: function () {

--- a/app/index.js
+++ b/app/index.js
@@ -52,8 +52,13 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 	writing: {
 		app: function () {
 			this.dest.mkdir('app');
-			// Assemble
-			this.dest.mkdir('app/assemble');
+
+			this.template('_package.json', 'package.json');
+			this.template('_bower.json', 'bower.json');
+			this.template('Gruntfile.js', 'Gruntfile.js');
+			this.template('README.md', 'README.md');
+
+
 			// Assembled HTML
 			this.dest.mkdir('app/modules');
 			// Compiled CSS
@@ -64,19 +69,11 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 			this.dest.mkdir('app/js/modules');
 			this.dest.mkdir('app/js/lib');
 
-			this.template('.gitkeep', 'app/js');
-			this.template('.gitkeep', 'app/js/plugins');
-			this.template('.gitkeep', 'app/js/modules');
-			this.template('.gitkeep', 'app/js/lib');
 			// Images
 			this.dest.mkdir('app/img');
 
 			this.src.copy('rocket.png', 'app/img/rocket.png');
 
-			this.template('_package.json', 'package.json');
-			this.template('_bower.json', 'bower.json');
-			this.template('Gruntfile.js', 'Gruntfile.js');
-			this.template('README.md', 'README.md');
 		},
 
 		html: function () {
@@ -98,8 +95,13 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 				cb();
 			}, true);
 
-			// Helpers
+		},
+
+		helpers: function () {
+			var cb = this.async();
+
 			this.remote('BarkleyREI', 'brei-assemble-helpers', 'master', function (err, remote) {
+
 				if (err) {
 					return cb(err);
 				}
@@ -111,7 +113,6 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 		},
 
 		sass: function () {
-
 			var cb = this.async();
 
 			this.remote('BarkleyREI', 'sass_boilerplate', 'master', function (err, remote) {
@@ -123,7 +124,6 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 
 				cb();
 			}, true);
-
 		},
 
 		projectfiles: function () {
@@ -132,10 +132,9 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 		}
 	},
 
-	end: function () {
-		this.installDependencies();
-
-		this.config.save();
+end: function () {
+	this.installDependencies();
+	this.config.save();
 	}
 });
 

--- a/app/index.js
+++ b/app/index.js
@@ -50,14 +50,8 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 	},
 
 	writing: {
-		app: function () {
+		folders: function () {
 			this.dest.mkdir('app');
-
-			this.template('_package.json', 'package.json');
-			this.template('_bower.json', 'bower.json');
-			this.template('Gruntfile.js', 'Gruntfile.js');
-			this.template('README.md', 'README.md');
-
 
 			// Assembled HTML
 			this.dest.mkdir('app/modules');
@@ -72,13 +66,20 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 			// Images
 			this.dest.mkdir('app/img');
 
-			this.src.copy('rocket.png', 'app/img/rocket.png');
-
 		},
 
-		html: function () {
-			// this.template('index.html', 'app/index.html');
-			// this.template('template.html', 'app/template.html');
+		app: function () {
+			this.template('_package.json', 'package.json');
+			this.template('_bower.json', 'bower.json');
+			this.template('Gruntfile.js', 'Gruntfile.js');
+			this.template('README.md', 'README.md');
+
+			// Add .gitkeep file to maintain file structure
+			this.src.copy('.gitkeep', 'app/js/plugins/.gitkeep');
+			this.src.copy('.gitkeep', 'app/js/modules/.gitkeep');
+			this.src.copy('.gitkeep', 'app/js/lib/.gitkeep');
+
+			this.src.copy('rocket.png', 'app/img/rocket.png');
 		},
 
 		assemble: function () {
@@ -101,7 +102,6 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 			var cb = this.async();
 
 			this.remote('BarkleyREI', 'brei-assemble-helpers', 'master', function (err, remote) {
-
 				if (err) {
 					return cb(err);
 				}

--- a/app/index.js
+++ b/app/index.js
@@ -73,6 +73,7 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 			this.template('_bower.json', 'bower.json');
 			this.template('Gruntfile.js', 'Gruntfile.js');
 			this.template('README.md', 'README.md');
+			this.template('.gitignore', '.gitignore');
 
 			// Add .gitkeep file to maintain file structure
 			this.src.copy('.gitkeep', 'app/js/plugins/.gitkeep');

--- a/app/templates/.gitignore
+++ b/app/templates/.gitignore
@@ -1,0 +1,6 @@
+*node_modules*
+*.sass-cache
+*.tmp*
+*bower_components*
+*.log*
+*.orig*

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -23,6 +23,9 @@ module.exports = function (grunt) {
     // Show elapsed time after tasks run
     require('time-grunt')(grunt);
 
+    // Assemble!
+    grunt.loadNpmTasks('assemble');
+
     // configurable paths
     var yeomanConfig = {
         app: 'app',
@@ -101,6 +104,10 @@ module.exports = function (grunt) {
                 files: ['<%%= yeoman.app %>/css/**/*.css'],
                 tasks: ['copy:styles', 'autoprefixer']
             },
+            assemble: {
+                files: ['<%= yeoman.app %>/assemble/**/*.hbs'],
+                tasks: ['clean:assemble', 'assemble']
+            },
             livereload: {
                 options: {
                     livereload: LIVERELOAD_PORT
@@ -173,7 +180,10 @@ module.exports = function (grunt) {
                 },
                 src: ['<%%= yeoman.deploy %>']
             },
-            server: '.tmp'
+            server: '.tmp',
+            assemble: {
+                src: ['<%= yeoman.app %>/*.html', '<%= yeoman.app %>/modules/*.html']
+            }
         },
         jshint: {
             options: {
@@ -365,8 +375,11 @@ module.exports = function (grunt) {
                 layout: 'default.hbs',
                 layoutdir: '<%= yeoman.app %>/assemble/layouts/',
                 helpers: '<%= yeoman.app %>/assemble/helpers/**/*.js',
-                partials: ['<%= yeoman.app %>/assemble/partials/{,*/}*.hbs', '<%= yeoman.app %>/assemble/modules/**/*'],
-            data: '<%= yeoman.app %>/assemble/fixtures/{,*/}*.json'
+                partials: [
+                    '<%= yeoman.app %>/assemble/partials/{,*/}*.hbs',
+                    '<%= yeoman.app %>/assemble/modules/**/*'
+                ],
+                data: '<%= yeoman.app %>/assemble/fixtures/{,*/}*.json'
             },
             templates: {
                 files: [{

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -1,4 +1,4 @@
-// Generated on <%= (new Date).toISOString().split('T')[0] %> using <%= pkg.name %> <%= pkg.version %>
+// Generated on 2014-10-15 using generator-brei-app 0.5.0
 'use strict';
 var LIVERELOAD_PORT = 35729;
 var lrSnippet = require('connect-livereload')({port: LIVERELOAD_PORT});
@@ -23,11 +23,14 @@ module.exports = function (grunt) {
     // Show elapsed time after tasks run
     require('time-grunt')(grunt);
 
+    // Assemble!
+    grunt.loadNpmTasks('assemble');
+
     // configurable paths
     var yeomanConfig = {
         app: 'app',
         dist: 'dist',
-        deploy: '<%= deployDirectory %>'
+        deploy: '../../deploy/site/'
     };
 
     grunt.initConfig({
@@ -35,10 +38,10 @@ module.exports = function (grunt) {
         modernizr: {
             dist: {
                 // [REQUIRED] Path to the build you're using for development.
-                'devFile' : 'app/plugins/modernizr/modernizr.js',
+                'devFile' : 'app/bower_components/modernizr/modernizr.js',
 
                 // [REQUIRED] Path to save out the built file.
-                'outputFile' : 'dist/js/plugins/modernizr.optimized.js',
+                'outputFile' : 'app/js/plugins/modernizr.optimized.js',
 
                 // Based on default settings on http://modernizr.com/download/
                 'extra' : {
@@ -75,9 +78,8 @@ module.exports = function (grunt) {
                 // You can override this by defining a 'files' array below.
                 'files' : {
                     'src': [
-                        '<%%= yeoman.app %>/js/**/*.js',
-                        '<%%= yeoman.app %>/css/**/*.css',
-                        '<%%= yeoman.app %>/sass/**/*.scss'
+                        '<%= yeoman.app %>/js/**/*.js',
+                        '<%= yeoman.app %>/css/**/*.css'
                     ]
                 },
 
@@ -92,25 +94,30 @@ module.exports = function (grunt) {
         watch: {
             compass: {
                 files: [
-                    '<%%= yeoman.app %>/sass/**/*.{scss,sass}',
-                    '<%%= yeoman.app %>/img/**/*.png'
+                    '<%= yeoman.app %>/sass/{,*/,*/*/}*.{scss,sass}',
+                    '/img/{,*/}*.png'
                 ],
                 tasks: ['compass:server', 'autoprefixer']
             },
             styles: {
-                files: ['<%%= yeoman.app %>/css/**/*.css'],
+                files: ['<%= yeoman.app %>/css/{,*/}*.css'],
                 tasks: ['copy:styles', 'autoprefixer']
+            },
+            assemble: {
+                files: ['<%= yeoman.app %>/assemble/**/*.hbs'],
+                tasks: ['clean:assemble', 'assemble']
             },
             livereload: {
                 options: {
                     livereload: LIVERELOAD_PORT
                 },
                 files: [
-                    '<%%= yeoman.app %>/*.html',
-                    '<%%= yeoman.app %>/modules/**/*.html',
-                    '.tmp/css/**/*.css',
-                    '{.tmp,<%%= yeoman.app %>}/js/**/*.js',
-                    '<%%= yeoman.app %>/img/**/*.{png,jpg,jpeg,gif,webp,svg}'
+                    '<%= yeoman.app %>/index.html',
+                    '<%= yeoman.app %>/css/{,*/}*.css',
+                    '<%= yeoman.app %>/js/{,*/}*.js',
+                    '<%= yeoman.app %>/assemble/helpers/{,*/}*.js',
+                    '<%= yeoman.app %>/assemble/fixtures/{,*/}*.json',
+                    '<%= yeoman.app %>/img/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
             }
         },
@@ -125,7 +132,7 @@ module.exports = function (grunt) {
                     middleware: function (connect) {
                         return [
                             lrSnippet,
-                            mountFolder(connect, '.tmp'),
+                            //mountFolder(connect, '.tmp'),
                             mountFolder(connect, yeomanConfig.app)
                         ];
                     }
@@ -135,7 +142,7 @@ module.exports = function (grunt) {
                 options: {
                     middleware: function (connect) {
                         return [
-                            mountFolder(connect, '.tmp'),
+                            //mountFolder(connect, '.tmp'),
                             mountFolder(connect, 'test')
                         ];
                     }
@@ -153,7 +160,7 @@ module.exports = function (grunt) {
         },
         open: {
             server: {
-                path: 'http://localhost:<%%= connect.options.port %>'
+                path: 'http://localhost:<%= connect.options.port %>'
             }
         },
         clean: {
@@ -161,9 +168,9 @@ module.exports = function (grunt) {
                 files: [{
                     dot: true,
                     src: [
-                        '.tmp',
-                        '<%%= yeoman.dist %>/*',
-                        '!<%%= yeoman.dist %>/.git*'
+                        //'.tmp',
+                        '<%= yeoman.dist %>/*',
+                        '!<%= yeoman.dist %>/.git*'
                     ]
                 }]
             },
@@ -171,9 +178,12 @@ module.exports = function (grunt) {
                 options: {
                     force: true
                 },
-                src: ['<%%= yeoman.deploy %>']
+                src: ['<%= yeoman.deploy %>']
             },
-            server: '.tmp'
+            server: '.tmp',
+            assemble: {
+                src: ['<%= yeoman.app %>/*.html', '<%= yeoman.app %>/modules/*.html']
+            }
         },
         jshint: {
             options: {
@@ -181,39 +191,48 @@ module.exports = function (grunt) {
             },
             all: [
                 'Gruntfile.js',
-                '<%%= yeoman.app %>/js/{,*/}*.js',
-                '!<%%= yeoman.app %>/js/plugins.js',
-                '!<%%= yeoman.app %>/js/plugins/*',
-                '!<%%= yeoman.app %>/js/vendor/*',
+                '<%= yeoman.app %>/js/{,*/}*.js',
+                '!<%= yeoman.app %>/js/plugins.js',
+                '!<%= yeoman.app %>/js/plugins/*',
+                '!<%= yeoman.app %>/js/vendor/*',
                 'test/spec/{,*/}*.js'
             ]
         },
+        mocha: {
+            all: {
+                options: {
+                    run: true,
+                    urls: ['http://localhost:<%= connect.options.port %>/index.html']
+                }
+            }
+        },
         compass: {
             options: {
-                sassDir: '<%%= yeoman.app %>/sass',
-                cssDir: '.tmp/css',
-                generatedImagesDir: '.tmp/img/generated',
-                imagesDir: '<%%= yeoman.app %>/img',
-                javascriptsDir: '<%%= yeoman.app %>/js',
-                fontsDir: '<%%= yeoman.app %>/sass/fonts',
-                importPath: '<%%= yeoman.app %>/plugins',
-                httpImagesPath: '/img',
-                httpGeneratedImagesPath: '/img/generated',
-                httpFontsPath: '/sass/fonts',
+                sassDir: '<%= yeoman.app %>/sass',
+                cssDir: '<%= yeoman.app %>/css',
+                generatedImagesDir: '<%= yeoman.app %>/img/generated',
+                //generatedImagesPath: '/img/generated',
+                imagesDir: '<%= yeoman.app %>/img',
+                //javascriptsDir: '<%= yeoman.app %>/js',
+                //fontsDir: '<%= yeoman.app %>/sass/fonts',
+                //importPath: '<%= yeoman.app %>/bower_components',
+                //httpImagesPath: '<%= yeoman.app %>/img',
+                httpGeneratedImagesPath: '../img/generated', // http://stackoverflow.com/questions/17448749/compass-grunt-contrib-compass-sprites-paths-problems
+                //httpFontsPath: '/sass/fonts',
                 relativeAssets: false,
                 outputStyle: 'compact',
                 debugInfo: false
             },
             dist: {
                 options: {
-                    generatedImagesDir: '<%%= yeoman.dist %>/img/generated',
+                    generatedImagesDir: '<%= yeoman.dist %>/img/generated',
                     debugInfo: false,
                     outputStyle: 'compressed'
                 }
             },
             server: {
                 options: {
-                    debugInfo: true
+                    debugInfo: false
                 }
             }
         },
@@ -230,26 +249,37 @@ module.exports = function (grunt) {
                 }]
             }
         },
+        // not used since Uglify task does concat,
+        // but still available if needed
+        /*concat: {
+            dist: {}
+        },*/
+        // not enabled since usemin task does concat and uglify
+        // check index.html to edit your build targets
+        // enable this task if you prefer defining your build targets here
+        /*uglify: {
+            dist: {}
+        },*/
         useminPrepare: {
             options: {
-                dest: '<%%= yeoman.dist %>'
+                dest: '<%= yeoman.dist %>'
             },
-            html: '<%%= yeoman.app %>/index.html'
+            html: '<%= yeoman.app %>/index.html'
         },
         usemin: {
             options: {
-                dirs: ['<%%= yeoman.dist %>']
+                dirs: ['<%= yeoman.dist %>']
             },
-            html: ['<%%= yeoman.dist %>/{,*/}*.html'],
-            css: ['<%%= yeoman.dist %>/css/{,*/}*.css']
+            html: ['<%= yeoman.dist %>/{,*/}*.html'],
+            css: ['<%= yeoman.dist %>/css/{,*/}*.css']
         },
         imagemin: {
             dist: {
                 files: [{
                     expand: true,
-                    cwd: '<%%= yeoman.app %>/img',
+                    cwd: '<%= yeoman.app %>/img',
                     src: '{,*/}*.{png,jpg,jpeg}',
-                    dest: '<%%= yeoman.dist %>/img'
+                    dest: '<%= yeoman.dist %>/img'
                 }]
             }
         },
@@ -257,9 +287,9 @@ module.exports = function (grunt) {
             dist: {
                 files: [{
                     expand: true,
-                    cwd: '<%%= yeoman.app %>/img',
+                    cwd: '<%= yeoman.app %>/img',
                     src: '{,*/}*.svg',
-                    dest: '<%%= yeoman.dist %>/img'
+                    dest: '<%= yeoman.dist %>/img'
                 }]
             }
         },
@@ -272,9 +302,9 @@ module.exports = function (grunt) {
             //
             // dist: {
             //     files: {
-            //         '<%%= yeoman.dist %>/css/main.css': [
+            //         '<%= yeoman.dist %>/css/main.css': [
             //             '.tmp/css/{,*/}*.css',
-            //             '<%%= yeoman.app %>/css/{,*/}*.css'
+            //             '<%= yeoman.app %>/css/{,*/}*.css'
             //         ]
             //     }
             // }
@@ -294,9 +324,9 @@ module.exports = function (grunt) {
                 },
                 files: [{
                     expand: true,
-                    cwd: '<%%= yeoman.app %>',
+                    cwd: '<%= yeoman.app %>',
                     src: '*.html',
-                    dest: '<%%= yeoman.dist %>'
+                    dest: '<%= yeoman.dist %>'
                 }]
             }
         },
@@ -306,8 +336,8 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     dot: true,
-                    cwd: '<%%= yeoman.app %>',
-                    dest: '<%%= yeoman.dist %>',
+                    cwd: '<%= yeoman.app %>',
+                    dest: '<%= yeoman.dist %>',
                     src: [
                         '*.{ico,png,txt}',
                         '.htaccess',
@@ -322,15 +352,15 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     dot: true,
-                    cwd: '<%%= yeoman.dist %>',
-                    dest: '<%%= yeoman.deploy %>',
+                    cwd: '<%= yeoman.dist %>',
+                    dest: '<%= yeoman.deploy %>',
                     src: ['./**']
                 }]
             },
             styles: {
                 expand: true,
                 dot: true,
-                cwd: '<%%= yeoman.app %>/css',
+                cwd: '<%= yeoman.app %>/css',
                 dest: '.tmp/css/',
                 src: '{,*/}*.css'
             }
@@ -347,9 +377,45 @@ module.exports = function (grunt) {
                 'compass:dist',
                 'copy:styles',
                 'imagemin',
-                'svgmin',
+                //'svgmin',
                 'htmlmin'
             ]
+        },
+        assemble: {
+            options: {
+                collections: [{
+                    name: 'module',
+                    sortby: 'title',
+                    sortorder: 'ascending'
+                }, {
+                    name: 'template',
+                    sortby: 'title',
+                    sortorder: 'ascending'
+                }],
+                layout: 'default.hbs',
+                layoutdir: '<%= yeoman.app %>/assemble/layouts/',
+                helpers: '<%= yeoman.app %>/assemble/helpers/**/*.js',
+                partials: ['<%= yeoman.app %>/assemble/partials/{,*/}*.hbs', '<%= yeoman.app %>/assemble/modules/**/*'],
+            data: '<%= yeoman.app %>/assemble/fixtures/{,*/}*.json'
+            },
+            templates: {
+                files: [{
+                    cwd: '<%= yeoman.app %>/assemble/modules/',
+                    dest: '<%= yeoman.app %>/modules/',
+                    expand: true,
+                    src: ['**/*.hbs']
+                }, {
+                    cwd: '<%= yeoman.app %>/assemble/',
+                    dest: '<%= yeoman.app %>/',
+                    expand: true,
+                    src: ['*.hbs', '!index.hbs']
+                }, {
+                    cwd: '<%= yeoman.app %>/assemble/',
+                    dest: '<%= yeoman.app %>/',
+                    expand: true,
+                    src: ['index.hbs']
+                }]
+            }
         }
     });
 
@@ -359,6 +425,8 @@ module.exports = function (grunt) {
         }
 
         grunt.task.run([
+            'clean:assemble',
+            'assemble',
             'clean:server',
             'concurrent:server',
             'autoprefixer',
@@ -372,7 +440,16 @@ module.exports = function (grunt) {
         'jshint'
     ]);
 
+    // grunt.registerTask('test', [
+    //     'clean:server',
+    //     'concurrent:test',
+    //     'autoprefixer',
+    //     'connect:test'
+    //     'mocha'
+    // ]);
+
     grunt.registerTask('build', [
+        'modernizr:dist',
         'clean:dist',
         'useminPrepare',
         'concurrent:dist',
@@ -381,8 +458,7 @@ module.exports = function (grunt) {
         'cssmin',
         'uglify',
         'copy:dist',
-        'usemin',
-        'modernizr:dist'
+        'usemin'
     ]);
 
     grunt.registerTask('deploy', [
@@ -391,7 +467,10 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask('default', [
+        'clean:assemble',
+        'assemble',
         'jshint',
+        //'test',
         'build'
     ]);
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -373,28 +373,28 @@ module.exports = function (grunt) {
                     sortorder: 'ascending'
                 }],
                 layout: 'default.hbs',
-                layoutdir: '<%= yeoman.app %>/assemble/layouts/',
-                helpers: '<%= yeoman.app %>/assemble/helpers/**/*.js',
+                layoutdir: '<%%= yeoman.app %>/assemble/layouts/',
+                helpers: '<%%= yeoman.app %>/assemble/helpers/**/*.js',
                 partials: [
-                    '<%= yeoman.app %>/assemble/partials/{,*/}*.hbs',
-                    '<%= yeoman.app %>/assemble/modules/**/*'
+                    '<%%= yeoman.app %>/assemble/partials/{,*/}*.hbs',
+                    '<%%= yeoman.app %>/assemble/modules/**/*'
                 ],
-                data: '<%= yeoman.app %>/assemble/fixtures/{,*/}*.json'
+                data: '<%%= yeoman.app %>/assemble/fixtures/{,*/}*.json'
             },
             templates: {
                 files: [{
-                    cwd: '<%= yeoman.app %>/assemble/modules/',
-                    dest: '<%= yeoman.app %>/modules/',
+                    cwd: '<%%= yeoman.app %>/assemble/modules/',
+                    dest: '<%%= yeoman.app %>/modules/',
                     expand: true,
                     src: ['**/*.hbs']
                 }, {
-                    cwd: '<%= yeoman.app %>/assemble/',
-                    dest: '<%= yeoman.app %>/',
+                    cwd: '<%%= yeoman.app %>/assemble/',
+                    dest: '<%%= yeoman.app %>/',
                     expand: true,
                     src: ['*.hbs', '!index.hbs']
                 }, {
-                    cwd: '<%= yeoman.app %>/assemble/',
-                    dest: '<%= yeoman.app %>/',
+                    cwd: '<%%= yeoman.app %>/assemble/',
+                    dest: '<%%= yeoman.app %>/',
                     expand: true,
                     src: ['index.hbs']
                 }]

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -1,4 +1,4 @@
-// Generated on 2014-10-15 using generator-brei-app 0.5.0
+// Generated on <%= (new Date).toISOString().split('T')[0] %> using <%= pkg.name %> <%= pkg.version %>
 'use strict';
 var LIVERELOAD_PORT = 35729;
 var lrSnippet = require('connect-livereload')({port: LIVERELOAD_PORT});
@@ -23,14 +23,11 @@ module.exports = function (grunt) {
     // Show elapsed time after tasks run
     require('time-grunt')(grunt);
 
-    // Assemble!
-    grunt.loadNpmTasks('assemble');
-
     // configurable paths
     var yeomanConfig = {
         app: 'app',
         dist: 'dist',
-        deploy: '../../deploy/site/'
+        deploy: '<%= deployDirectory %>'
     };
 
     grunt.initConfig({
@@ -38,10 +35,10 @@ module.exports = function (grunt) {
         modernizr: {
             dist: {
                 // [REQUIRED] Path to the build you're using for development.
-                'devFile' : 'app/bower_components/modernizr/modernizr.js',
+                'devFile' : 'app/plugins/modernizr/modernizr.js',
 
                 // [REQUIRED] Path to save out the built file.
-                'outputFile' : 'app/js/plugins/modernizr.optimized.js',
+                'outputFile' : 'dist/js/plugins/modernizr.optimized.js',
 
                 // Based on default settings on http://modernizr.com/download/
                 'extra' : {
@@ -78,8 +75,9 @@ module.exports = function (grunt) {
                 // You can override this by defining a 'files' array below.
                 'files' : {
                     'src': [
-                        '<%= yeoman.app %>/js/**/*.js',
-                        '<%= yeoman.app %>/css/**/*.css'
+                        '<%%= yeoman.app %>/js/**/*.js',
+                        '<%%= yeoman.app %>/css/**/*.css',
+                        '<%%= yeoman.app %>/sass/**/*.scss'
                     ]
                 },
 
@@ -94,30 +92,25 @@ module.exports = function (grunt) {
         watch: {
             compass: {
                 files: [
-                    '<%= yeoman.app %>/sass/{,*/,*/*/}*.{scss,sass}',
-                    '/img/{,*/}*.png'
+                    '<%%= yeoman.app %>/sass/**/*.{scss,sass}',
+                    '<%%= yeoman.app %>/img/**/*.png'
                 ],
                 tasks: ['compass:server', 'autoprefixer']
             },
             styles: {
-                files: ['<%= yeoman.app %>/css/{,*/}*.css'],
+                files: ['<%%= yeoman.app %>/css/**/*.css'],
                 tasks: ['copy:styles', 'autoprefixer']
-            },
-            assemble: {
-                files: ['<%= yeoman.app %>/assemble/**/*.hbs'],
-                tasks: ['clean:assemble', 'assemble']
             },
             livereload: {
                 options: {
                     livereload: LIVERELOAD_PORT
                 },
                 files: [
-                    '<%= yeoman.app %>/index.html',
-                    '<%= yeoman.app %>/css/{,*/}*.css',
-                    '<%= yeoman.app %>/js/{,*/}*.js',
-                    '<%= yeoman.app %>/assemble/helpers/{,*/}*.js',
-                    '<%= yeoman.app %>/assemble/fixtures/{,*/}*.json',
-                    '<%= yeoman.app %>/img/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+                    '<%%= yeoman.app %>/*.html',
+                    '<%%= yeoman.app %>/modules/**/*.html',
+                    '.tmp/css/**/*.css',
+                    '{.tmp,<%%= yeoman.app %>}/js/**/*.js',
+                    '<%%= yeoman.app %>/img/**/*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
             }
         },
@@ -132,7 +125,7 @@ module.exports = function (grunt) {
                     middleware: function (connect) {
                         return [
                             lrSnippet,
-                            //mountFolder(connect, '.tmp'),
+                            mountFolder(connect, '.tmp'),
                             mountFolder(connect, yeomanConfig.app)
                         ];
                     }
@@ -142,7 +135,7 @@ module.exports = function (grunt) {
                 options: {
                     middleware: function (connect) {
                         return [
-                            //mountFolder(connect, '.tmp'),
+                            mountFolder(connect, '.tmp'),
                             mountFolder(connect, 'test')
                         ];
                     }
@@ -160,7 +153,7 @@ module.exports = function (grunt) {
         },
         open: {
             server: {
-                path: 'http://localhost:<%= connect.options.port %>'
+                path: 'http://localhost:<%%= connect.options.port %>'
             }
         },
         clean: {
@@ -168,9 +161,9 @@ module.exports = function (grunt) {
                 files: [{
                     dot: true,
                     src: [
-                        //'.tmp',
-                        '<%= yeoman.dist %>/*',
-                        '!<%= yeoman.dist %>/.git*'
+                        '.tmp',
+                        '<%%= yeoman.dist %>/*',
+                        '!<%%= yeoman.dist %>/.git*'
                     ]
                 }]
             },
@@ -178,12 +171,9 @@ module.exports = function (grunt) {
                 options: {
                     force: true
                 },
-                src: ['<%= yeoman.deploy %>']
+                src: ['<%%= yeoman.deploy %>']
             },
-            server: '.tmp',
-            assemble: {
-                src: ['<%= yeoman.app %>/*.html', '<%= yeoman.app %>/modules/*.html']
-            }
+            server: '.tmp'
         },
         jshint: {
             options: {
@@ -191,48 +181,39 @@ module.exports = function (grunt) {
             },
             all: [
                 'Gruntfile.js',
-                '<%= yeoman.app %>/js/{,*/}*.js',
-                '!<%= yeoman.app %>/js/plugins.js',
-                '!<%= yeoman.app %>/js/plugins/*',
-                '!<%= yeoman.app %>/js/vendor/*',
+                '<%%= yeoman.app %>/js/{,*/}*.js',
+                '!<%%= yeoman.app %>/js/plugins.js',
+                '!<%%= yeoman.app %>/js/plugins/*',
+                '!<%%= yeoman.app %>/js/vendor/*',
                 'test/spec/{,*/}*.js'
             ]
         },
-        mocha: {
-            all: {
-                options: {
-                    run: true,
-                    urls: ['http://localhost:<%= connect.options.port %>/index.html']
-                }
-            }
-        },
         compass: {
             options: {
-                sassDir: '<%= yeoman.app %>/sass',
-                cssDir: '<%= yeoman.app %>/css',
-                generatedImagesDir: '<%= yeoman.app %>/img/generated',
-                //generatedImagesPath: '/img/generated',
-                imagesDir: '<%= yeoman.app %>/img',
-                //javascriptsDir: '<%= yeoman.app %>/js',
-                //fontsDir: '<%= yeoman.app %>/sass/fonts',
-                //importPath: '<%= yeoman.app %>/bower_components',
-                //httpImagesPath: '<%= yeoman.app %>/img',
-                httpGeneratedImagesPath: '../img/generated', // http://stackoverflow.com/questions/17448749/compass-grunt-contrib-compass-sprites-paths-problems
-                //httpFontsPath: '/sass/fonts',
+                sassDir: '<%%= yeoman.app %>/sass',
+                cssDir: '.tmp/css',
+                generatedImagesDir: '.tmp/img/generated',
+                imagesDir: '<%%= yeoman.app %>/img',
+                javascriptsDir: '<%%= yeoman.app %>/js',
+                fontsDir: '<%%= yeoman.app %>/sass/fonts',
+                importPath: '<%%= yeoman.app %>/plugins',
+                httpImagesPath: '/img',
+                httpGeneratedImagesPath: '/img/generated',
+                httpFontsPath: '/sass/fonts',
                 relativeAssets: false,
                 outputStyle: 'compact',
                 debugInfo: false
             },
             dist: {
                 options: {
-                    generatedImagesDir: '<%= yeoman.dist %>/img/generated',
+                    generatedImagesDir: '<%%= yeoman.dist %>/img/generated',
                     debugInfo: false,
                     outputStyle: 'compressed'
                 }
             },
             server: {
                 options: {
-                    debugInfo: false
+                    debugInfo: true
                 }
             }
         },
@@ -249,37 +230,26 @@ module.exports = function (grunt) {
                 }]
             }
         },
-        // not used since Uglify task does concat,
-        // but still available if needed
-        /*concat: {
-            dist: {}
-        },*/
-        // not enabled since usemin task does concat and uglify
-        // check index.html to edit your build targets
-        // enable this task if you prefer defining your build targets here
-        /*uglify: {
-            dist: {}
-        },*/
         useminPrepare: {
             options: {
-                dest: '<%= yeoman.dist %>'
+                dest: '<%%= yeoman.dist %>'
             },
-            html: '<%= yeoman.app %>/index.html'
+            html: '<%%= yeoman.app %>/index.html'
         },
         usemin: {
             options: {
-                dirs: ['<%= yeoman.dist %>']
+                dirs: ['<%%= yeoman.dist %>']
             },
-            html: ['<%= yeoman.dist %>/{,*/}*.html'],
-            css: ['<%= yeoman.dist %>/css/{,*/}*.css']
+            html: ['<%%= yeoman.dist %>/{,*/}*.html'],
+            css: ['<%%= yeoman.dist %>/css/{,*/}*.css']
         },
         imagemin: {
             dist: {
                 files: [{
                     expand: true,
-                    cwd: '<%= yeoman.app %>/img',
+                    cwd: '<%%= yeoman.app %>/img',
                     src: '{,*/}*.{png,jpg,jpeg}',
-                    dest: '<%= yeoman.dist %>/img'
+                    dest: '<%%= yeoman.dist %>/img'
                 }]
             }
         },
@@ -287,9 +257,9 @@ module.exports = function (grunt) {
             dist: {
                 files: [{
                     expand: true,
-                    cwd: '<%= yeoman.app %>/img',
+                    cwd: '<%%= yeoman.app %>/img',
                     src: '{,*/}*.svg',
-                    dest: '<%= yeoman.dist %>/img'
+                    dest: '<%%= yeoman.dist %>/img'
                 }]
             }
         },
@@ -302,9 +272,9 @@ module.exports = function (grunt) {
             //
             // dist: {
             //     files: {
-            //         '<%= yeoman.dist %>/css/main.css': [
+            //         '<%%= yeoman.dist %>/css/main.css': [
             //             '.tmp/css/{,*/}*.css',
-            //             '<%= yeoman.app %>/css/{,*/}*.css'
+            //             '<%%= yeoman.app %>/css/{,*/}*.css'
             //         ]
             //     }
             // }
@@ -324,9 +294,9 @@ module.exports = function (grunt) {
                 },
                 files: [{
                     expand: true,
-                    cwd: '<%= yeoman.app %>',
+                    cwd: '<%%= yeoman.app %>',
                     src: '*.html',
-                    dest: '<%= yeoman.dist %>'
+                    dest: '<%%= yeoman.dist %>'
                 }]
             }
         },
@@ -336,8 +306,8 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     dot: true,
-                    cwd: '<%= yeoman.app %>',
-                    dest: '<%= yeoman.dist %>',
+                    cwd: '<%%= yeoman.app %>',
+                    dest: '<%%= yeoman.dist %>',
                     src: [
                         '*.{ico,png,txt}',
                         '.htaccess',
@@ -352,15 +322,15 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     dot: true,
-                    cwd: '<%= yeoman.dist %>',
-                    dest: '<%= yeoman.deploy %>',
+                    cwd: '<%%= yeoman.dist %>',
+                    dest: '<%%= yeoman.deploy %>',
                     src: ['./**']
                 }]
             },
             styles: {
                 expand: true,
                 dot: true,
-                cwd: '<%= yeoman.app %>/css',
+                cwd: '<%%= yeoman.app %>/css',
                 dest: '.tmp/css/',
                 src: '{,*/}*.css'
             }
@@ -377,7 +347,7 @@ module.exports = function (grunt) {
                 'compass:dist',
                 'copy:styles',
                 'imagemin',
-                //'svgmin',
+                'svgmin',
                 'htmlmin'
             ]
         },
@@ -440,16 +410,7 @@ module.exports = function (grunt) {
         'jshint'
     ]);
 
-    // grunt.registerTask('test', [
-    //     'clean:server',
-    //     'concurrent:test',
-    //     'autoprefixer',
-    //     'connect:test'
-    //     'mocha'
-    // ]);
-
     grunt.registerTask('build', [
-        'modernizr:dist',
         'clean:dist',
         'useminPrepare',
         'concurrent:dist',
@@ -458,7 +419,8 @@ module.exports = function (grunt) {
         'cssmin',
         'uglify',
         'copy:dist',
-        'usemin'
+        'usemin',
+        'modernizr:dist'
     ]);
 
     grunt.registerTask('deploy', [
@@ -470,7 +432,6 @@ module.exports = function (grunt) {
         'clean:assemble',
         'assemble',
         'jshint',
-        //'test',
         'build'
     ]);
 

--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -1,27 +1,42 @@
 # <%= appname %>
 
-CMS:
+##READ THIS
 
-Confluence:
+Setup:
+- Install Node Modules and Bower Components.
+    - `npm install`
+    - `bower install`
 
-JIRA:
+Coding, testing:
+- Spins up a server, starts compass, auto refreshes on save.
+	- `grunt server`
 
-Epic:
+- Runs JSLint, maybe other validations down the road.
+	- `grunt check`
 
-## Project Info
+Build:
+- Compresses and concatenates all files and copies them to ./dist.
+	- `grunt build`
 
-### SVN
+Deploy:
+- Deploys the built code to deploy/site/_files
+	- `grunt deploy`
 
-Add `dist`, `.sass-cache', `node_modules` to SVN ignore if not already ignored.
 
-### Build
+##CONVENTIONS
+1) Modules
+- module names must match for both the `.hbs` and `.scss`.
+ - ex: `assemble/modules/_global-footer.hbs` & `sass/modules/_global-footer.scss`
+- class names match module names
+ - ex: `_global-footer.hbs` => `.global-footer { // }`
 
-`grunt` to run jshint and build
+2) Partials
+- Nest partials in related groups, followed by the group name, without a preceeding `_`
+ - ex: `assemble/partials/header/contact-header.hbs`
+ - ex: `assemble/partials/carousel/controls-carousel.hbs`
+- Same conventions for Sass, but with a preceding `_`
+ - ex: `sass/partials/header/_contact-header.scss`
+- Add partial and module sass files in `main.scss` under their respective "partials" or "modules" sections.
 
-`grunt check` to run jshint
-
-`grunt build` to only build
-
-### Deployment
-
-`grunt deploy` to move to deployment folder
+3) Never write static text. Always reference JSON (or possibly XML) data via a helper
+ - ex: `<p>{{company.name.first-name}}</p>` instead of `<p>Barkley</p>

--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -1,5 +1,18 @@
 # <%= appname %>
 
+CMS:
+
+Confulence:
+
+JIRA:
+
+Epic:
+
+##Project Info:
+
+###SVN
+Add `dist`, `.sass-cache', `node_modules` to SVN ignore if not already ignored.
+
 ##READ THIS
 
 Setup:

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,7 +23,8 @@
     "matchdep": "~0.3.0",
     "connect-livereload": "~0.5.1",
     "grunt-modernizr": "~0.6.0",
-    "time-grunt": "~1.0.0"
+    "time-grunt": "~1.0.0",
+    "assemble": "~0.4.42"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-brei-app",
-    "version": "1.0.1",
+    "version": "2.0.1",
     "description": "Yeoman generator",
     "license": "MIT",
     "main": "app/index.js",
@@ -18,7 +18,11 @@
 	}, {
 		"name": "Ryan Sprake",
 		"url": "https://github.com/eightdotthree"
-	}],
+	},{
+        "name": "Joseph Dillon",
+        "url": "https://github.com/jdillon522"
+        }
+    ],
     "engines": {
         "node": ">=0.10.0",
 		"npm": ">=1.2.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-brei-app",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Yeoman generator",
     "license": "MIT",
     "main": "app/index.js",


### PR DESCRIPTION
@nessthehero 
This PR will take the generator to V.2.0.1

Major changes:

1) Addition of Assemble.io to manage our static code.
 - This is abstracted into two parts:
   - The [BREI-Assemble-Structure](https://github.com/BarkleyREI/brei-assemble-structure) repo to manage the project structure.
   - The [BREI-Assemble-Helpers](https://github.com/BarkleyREI/brei-assemble-helpers) repo to manage our soon-to-be growing library of custom Handlebar helpers.

2) The `app/js/*` directory now includes `app/js/lib`, `app/js/plugins/`, and `app/js/modules`. Each folder is currently empty and contains a `.gitkeep` file.

3) A standard `.gitignore` was added to the project.
