### PR TITLE
Add auto generator to add partial and module sass files to main.scss

### DIFF
--- a/generators/app/templates/Gruntfile.js
+++ b/generators/app/templates/Gruntfile.js
@@ -26,6 +26,9 @@ module.exports = function (grunt) {
     // Assemble!
     grunt.loadNpmTasks('assemble');
 
+    // For executing the updateScss.js script in app/assemble/helpers
+    grunt.loadNpmTasks('grunt-execute');
+
     // configurable paths
     var yeomanConfig = {
         app: 'app',
@@ -98,7 +101,7 @@ module.exports = function (grunt) {
                     '<%%= yeoman.app %>/sass/**/*.{scss,sass}',
                     '<%%= yeoman.app %>/img/**/*.png'
                 ],
-                tasks: ['compass:server', 'autoprefixer']
+                tasks: ['compass:server', 'autoprefixer', 'execute:target']
             },
             styles: {
                 files: ['<%%= yeoman.app %>/css/**/*.css'],
@@ -106,7 +109,7 @@ module.exports = function (grunt) {
             },
             assemble: {
                 files: ['<%= yeoman.app %>/assemble/**/*.hbs'],
-                tasks: ['clean:assemble', 'assemble']
+                tasks: ['clean:assemble', 'assemble', 'execute:target']
             },
             livereload: {
                 options: {
@@ -398,6 +401,11 @@ module.exports = function (grunt) {
                     expand: true,
                     src: ['index.hbs']
                 }]
+            }
+        },
+        execute: {
+            target: {
+                src: ['<%%= yeoman.app %>/assemble/helpers/updateScss.js']
             }
         }
     });

--- a/generators/app/templates/Gruntfile.js
+++ b/generators/app/templates/Gruntfile.js
@@ -101,15 +101,15 @@ module.exports = function (grunt) {
                     '<%%= yeoman.app %>/sass/**/*.{scss,sass}',
                     '<%%= yeoman.app %>/img/**/*.png'
                 ],
-                tasks: ['compass:server', 'autoprefixer', 'execute:target']
+                tasks: ['compass:server', 'autoprefixer']
             },
             styles: {
                 files: ['<%%= yeoman.app %>/css/**/*.css'],
                 tasks: ['copy:styles', 'autoprefixer']
             },
             assemble: {
-                files: ['<%= yeoman.app %>/assemble/**/*.hbs'],
-                tasks: ['clean:assemble', 'assemble', 'execute:target']
+                files: ['<%%= yeoman.app %>/assemble/**/*.hbs'],
+                tasks: ['clean:assemble', 'assemble']
             },
             livereload: {
                 options: {
@@ -122,6 +122,13 @@ module.exports = function (grunt) {
                     '{.tmp,<%%= yeoman.app %>}/js/**/*.js',
                     '<%%= yeoman.app %>/img/**/*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
+            },
+            execute: {
+                files: [
+                    '<%%= yeoman.app %>/assemble/modules/*.hbs',
+                    '<%%= yeoman.app %>/assemble/partials/*.hbs',
+                ],
+                tasks: ['execute:target']
             }
         },
         connect: {
@@ -185,7 +192,7 @@ module.exports = function (grunt) {
             },
             server: '.tmp',
             assemble: {
-                src: ['<%= yeoman.app %>/*.html', '<%= yeoman.app %>/modules/*.html']
+                src: ['<%%= yeoman.app %>/*.html', '<%%= yeoman.app %>/modules/*.html']
             }
         },
         jshint: {

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -24,7 +24,8 @@
     "connect-livereload": "~0.5.1",
     "grunt-modernizr": "~0.6.0",
     "time-grunt": "~1.0.0",
-    "assemble": "~0.4.42"
+    "assemble": "~0.4.42",
+    "grunt-execute": "^0.2.2"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-brei-app",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Yeoman generator",
     "license": "MIT",
     "main": "app/index.js",


### PR DESCRIPTION
This PR puts together the other pieces with the grunt tasks. 

Right now, its only going to look for one layer of assemble files and output one corrosponding `_assemble-partials.scss` and `_assemble-modules.scss` each. 

Resolves https://github.com/BarkleyREI/generator-brei-app/issues/31