### PR TITLE
Fixed: Module sub generator throws error #33

### DIFF
--- a/generators/module/index.js
+++ b/generators/module/index.js
@@ -38,8 +38,8 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 				moduleName = moduleName.replace(/_/g, '-');
 			}
 			// Remove any file extensions
-			if (/\..+/.test(partialName)) {
-				partialName = partialName.replace(/\..+/, '');
+			if (/\..+/.test(moduleName)) {
+				moduleName = moduleName.replace(/\..+/, '');
 			}
 
 			this.moduleName = moduleName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-brei-app",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Yeoman generator",
     "license": "MIT",
     "main": "app/index.js",


### PR DESCRIPTION
@nessthehero 
Fixed the bug. I had added the last check to the partial generator ...

```
// Remove any file extensions
if (/\..+/.test(partialName)) {
    partialName = partialName.replace(/\..+/, '');
}
```

And then I copied it over to the module generator and in my excitement forgot to test it (all my latter tests used the partial generator.)

... Time to add some unit tests. haha