### PR TITLE
Pattern Library Sub Generator 

### DIFF
--- a/generators/pattern/index.js
+++ b/generators/pattern/index.js
@@ -67,18 +67,24 @@ var BreiAppGenerator = yeoman.generators.Base.extend({
 
 	writing: {
 		pattern: function () {
-			var cb = this.async();
-			var path = this.type + '/' + this.name + '/';
 			var self = this;
+			var cb = this.async();
+			var fromPath = this.type + '/' + this.name + '/';
+
+			var toPathHBS = this.type !== 'templates' ?
+											'app/assemble/' + self.type + '/' + self.formattedNameHBS :
+											'app/assemble/' + self.formattedNameHBS;
+			var toPathSCSS = 'app/sass/' + self.type + '/' + self.formattedNameSASS;
+
 			// Directory Structure
-			this.remote('jdillon522', 'brei-pattern-library', 'master', function (err, remote) {
+			this.remote('BarkleyREI', 'brei-pattern-library', 'master', function (err, remote) {
 				if (err) {
 					console.log('ERROR WHILE FETCHING PATTER', err);
 					return cb(err);
 				}
 
-				remote.copy(path + self.formattedNameHBS, 'app/assemble/' + self.type + '/' + self.formattedNameHBS);
-				remote.copy(path + self.formattedNameSASS, 'app/sass/' + self.type + '/' + self.formattedNameSASS);
+				remote.copy(fromPath + self.formattedNameHBS, toPathHBS);
+				remote.copy(fromPath + self.formattedNameSASS, toPathSCSS);
 
 				cb();
 			}, true);

--- a/generators/pattern/index.js
+++ b/generators/pattern/index.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var yeoman = require('yeoman-generator');
+
+var BreiAppGenerator = yeoman.generators.Base.extend({
+	initializing: function () {
+		this.pkg = require('../../package.json');
+	},
+
+	prompting: function () {
+		var done = this.async();
+
+		var prompts = [{
+			type: 'input',
+			name: 'type',
+			message: 'Pattern type: module, partial, or template',
+			default: 'module'
+		},
+		{
+			type: 'input',
+			name: 'name',
+			message: 'Pattern Name: basic-footer, breadcrumbs, etc',
+			default: 'basic'
+		}];
+
+		this.prompt(prompts, function (props) {
+			var name = props.name;
+			var type = props.type;
+			var formattedNameSASS, formattedNameHBS;
+
+			if (!/s$/.test(type)) {
+				type = type + 's';
+			}
+
+			// // Remove the first _ (or __)
+			if (/^_/g.test(name)) {
+				name = name.replace(/^_+/, '');
+			}
+			// Change all whitespace to -
+			if (/\s/g.test(name)) {
+				name = name.replace(/\s/g, '-');
+			}
+			// Change all remaining _ to -
+			if (/_/g.test(name)) {
+				name = name.replace(/_/g, '-');
+			}
+			// Remove any file extensions
+			if (/\..+/g.test(name)) {
+				name = name.replace(/\..+/g, '');
+			}
+
+			if (type === 'modules') {
+				formattedNameHBS = '_' + name + '.hbs';
+			} else {
+				formattedNameHBS = name + '.hbs';
+			}
+			formattedNameSASS = '_' + name + '.scss';
+
+			this.type = type;
+			this.name = name;
+			this.formattedNameHBS = formattedNameHBS;
+			this.formattedNameSASS = formattedNameSASS;
+
+			done();
+		}.bind(this));
+	},
+
+	writing: {
+		pattern: function () {
+			var cb = this.async();
+			var path = this.type + '/' + this.name + '/';
+			var self = this;
+			// Directory Structure
+			this.remote('jdillon522', 'brei-pattern-library', 'master', function (err, remote) {
+				if (err) {
+					console.log('ERROR WHILE FETCHING PATTER', err);
+					return cb(err);
+				}
+
+				remote.copy(path + self.formattedNameHBS, 'app/assemble/' + self.type + '/' + self.formattedNameHBS);
+				remote.copy(path + self.formattedNameSASS, 'app/sass/' + self.type + '/' + self.formattedNameSASS);
+
+				cb();
+			}, true);
+		}
+	}
+});
+
+module.exports = BreiAppGenerator;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
---reporter spec
+--reporter list
+--inline-diffs
 --timeout 16000
 --bail

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --reporter spec
 --timeout 16000
-
+--bail

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -6,7 +6,7 @@ var path = require('path');
 var assert = require('yeoman-generator').assert;
 var helpers = require('yeoman-generator').test;
 var os = require('os');
-var fs = require('fs');
+// var fs = require('fs');
 
 /**
  * Test basic file generation,
@@ -14,7 +14,7 @@ var fs = require('fs');
  */
 describe('BREI-APP PROJECT GENERATOR', function(){
   describe('Main Generator', function () {
-    before(function (done) {
+    before(function mainGenerator(done) {
       helpers.run(path.join(__dirname, '../generators/app'))
         .inDir(path.join(os.tmpdir(), './temp'))
         .withOptions({
@@ -113,12 +113,8 @@ describe('BREI-APP PROJECT GENERATOR', function(){
 
   describe('Template Sub-Generator', function () {
     describe('Create new template', function() {
-      before(function (done) {
+      before(function template(done) {
         helpers.run(path.join(__dirname, '../generators/template'))
-          .inDir(path.join(os.tmpdir(), './temp/template'))
-          .withOptions({
-            'skip-install': true
-          })
           .withPrompt({
             templateName: 'test template'
           })
@@ -140,30 +136,26 @@ describe('BREI-APP PROJECT GENERATOR', function(){
       });
     });
 
-    describe('Test updateScss.js', function() {
-      it('Created no-scss.scss', function() {
-        fs.writeFileSync('app/assemble/no-scss.hbs', 'no-scss');
-        setTimeout(function() {
-          assert.file([
-            'app/assemble/no-scss.hbs',
-            'app/sass/templates/no-scss.scss'
-          ]);
+    // describe('Test updateScss.js', function() {
+    //   it('Created no-scss.scss', function() {
+    //     fs.writeFileSync('app/assemble/no-scss.hbs', 'no-scss');
+    //     setTimeout(function() {
+    //       assert.file([
+    //         'app/assemble/no-scss.hbs',
+    //         'app/sass/templates/_no-scss.scss'
+    //       ]);
 
-          assert.fileContent('app/sass/templates/_assemble-templates.scss', /@import\s+"home-page";\n@import\s+"test-template.scss";\n@import\s+"no-scss";/);
+    //       assert.fileContent('app/sass/templates/_assemble-templates.scss', /@import\s+"home-page";\n@import\s+"test-template.scss";\n@import\s+"no-scss";/);
 
-        }, 100);
-      });
-    });
+    //     }, 100);
+    //   });
+    // });
   });
 
   describe('Module Sub-Generator', function () {
     describe('Create new module', function() {
-      before(function (done) {
+      before(function module(done) {
         helpers.run(path.join(__dirname, '../generators/module'))
-          .inDir(path.join(os.tmpdir(), './temp/module'))
-          .withOptions({
-            'skip-install': true
-          })
           .withPrompt({
             moduleName: 'test module'
           })
@@ -185,30 +177,26 @@ describe('BREI-APP PROJECT GENERATOR', function(){
       });
     });
 
-    describe('Test updateScss.js', function() {
-      it('Created no-scss.scss', function() {
-        fs.writeFileSync('app/assemble/modules/_no-scss.hbs', 'no-scss');
-        setTimeout(function() {
-          assert.file([
-            'app/assemble/modules/_no-scss.hbs',
-            'app/sass/modules/_no-scss.scss'
-          ]);
+    // describe('Test updateScss.js', function() {
+    //   it('Created no-scss.scss', function() {
+    //     fs.writeFileSync('app/assemble/modules/_no-scss.hbs', 'no-scss');
+    //     setTimeout(function() {
+    //       assert.file([
+    //         'app/assemble/modules/_no-scss.hbs',
+    //         'app/sass/modules/_no-scss.scss'
+    //       ]);
 
-          assert.fileContent('app/sass/modules/_assemble-modules.scss', /@import\s+"test-module.scss";\n@import\s+"no-scss";/);
+    //       assert.fileContent('app/sass/modules/_assemble-modules.scss', /@import\s+"test-module.scss";\n@import\s+"no-scss";/);
 
-        }, 100);
-      });
-    });
+    //     }, 100);
+    //   });
+    // });
   });
 
   describe('Partial Sub-Generator', function () {
     describe('Create new partial', function() {
-      before(function (done) {
+      before(function partial(done) {
         helpers.run(path.join(__dirname, '../generators/partial'))
-          .inDir(path.join(os.tmpdir(), './temp/partial'))
-          .withOptions({
-            'skip-install': true
-          })
           .withPrompt({
             partialName: 'test partial'
           })
@@ -230,20 +218,112 @@ describe('BREI-APP PROJECT GENERATOR', function(){
       });
     });
 
-    describe('Test updateScss.js', function() {
-      it('Created no-scss.scss', function() {
-        fs.writeFileSync('app/assemble/partials/_no-scss.hbs', 'no-scss');
-        setTimeout(function() {
-          assert.file([
-            'app/assemble/partials/no-scss.hbs',
-            'app/sass/partials/_no-scss.scss'
-          ]);
+    // describe('Test updateScss.js', function() {
+    //   it('Created no-scss.scss', function() {
+    //     fs.writeFileSync('app/assemble/partials/_no-scss.hbs', 'no-scss');
+    //     setTimeout(function() {
+    //       assert.file([
+    //         'app/assemble/partials/no-scss.hbs',
+    //         'app/sass/partials/_no-scss.scss'
+    //       ]);
 
-          assert.fileContent('app/sass/partials/_assemble-partials.scss', /@import\s+"test-partial.scss";\n@import\s+"no-scss";/);
+    //       assert.fileContent('app/sass/partials/_assemble-partials.scss', /@import\s+"test-partial.scss";\n@import\s+"no-scss";/);
 
-        }, 100);
+    //     }, 100);
+    //   });
+    // });
+  });
+
+  describe('Pattern Library Sub-Generator', function () {
+    describe('Import Partial Pattern', function() {
+      before(function partialPattern(done) {
+        helpers.run(path.join(__dirname, '../generators/pattern'))
+          .withPrompt({
+            type: 'partials',
+            name: 'test pattern partial'
+          })
+          .on('end', done);
+      });
+
+      it('Created test-partial.hbs and _test-partial.scss', function() {
+        assert.file([
+          'app/assemble/partials/test-partial.hbs',
+          'app/sass/partials/_test-partial.scss'
+        ]);
+      });
+
+      it('Test-pattern-partial .hbs && .scss have the right content', function() {
+        assert.fileContent([
+          ['app/assemble/partials/test-pattern-partial.hbs', /test-pattern-partial/],
+          ['app/sass/partials/_test-pattern-partial.scss', /\.test-pattern-partial {\n\s+\/\/\sAwesome styles\n}/]
+        ]);
       });
     });
+
+    describe('Import Module Pattern', function() {
+      before(function modulePattern(done) {
+        helpers.run(path.join(__dirname, '../generators/pattern'))
+          .withPrompt({
+            type: 'modules',
+            name: 'test pattern module'
+          })
+          .on('end', done);
+      });
+
+      it('Created test-pattern-modules.hbs and _test-pattern-modules.scss', function() {
+        assert.file([
+          'app/assemble/moduless/test-pattern-modules.hbs',
+          'app/sass/moduless/_test-pattern-modules.scss'
+        ]);
+      });
+
+      it('Test-pattern-modules .hbs && .scss have the right content', function() {
+        assert.fileContent([
+          ['app/assemble/moduless/test-pattern-modules.hbs', /title\:\stest-pattern-modules|\s+test-pattern-modules/],
+          ['app/sass/moduless/_test-pattern-modules.scss', /\.test-pattern-modules {\n\s+\/\/\sAwesome styles\n}/]
+        ]);
+      });
+    });
+
+    describe('Import Template Pattern', function() {
+      before(function templatePattern(done) {
+        helpers.run(path.join(__dirname, '../generators/pattern'))
+          .withPrompt({
+            type: 'template',
+            name: 'test pattern template'
+          })
+          .on('end', done);
+      });
+
+      it('Created test-pattern-template.hbs and _test-pattern-template.scss', function() {
+        assert.file([
+          'app/assemble/templates/test-pattern-template.hbs',
+          'app/sass/templates/_test-pattern-template.scss'
+        ]);
+      });
+
+      it('Test-pattern-template .hbs && .scss have the right content', function() {
+        assert.fileContent([
+          ['app/assemble/templates/test-pattern-template.hbs', /title\:\stest-pattern-template|\s+test-pattern-template/],
+          ['app/sass/templates/_test-pattern-template.scss', /\.test-pattern-template {\n\s+\/\/\sAwesome styles\n}/]
+        ]);
+      });
+    });
+
+    // describe('Test updateScss.js', function() {
+    //   it('Created no-scss.scss', function() {
+    //     fs.writeFileSync('app/assemble/partials/no-scss.hbs', 'no-scss');
+    //     setTimeout(function() {
+    //       assert.file([
+    //         'app/assemble/partials/no-scss.hbs',
+    //         'app/sass/partials/_no-scss.scss'
+    //       ]);
+
+    //       assert.fileContent('app/sass/partials/_assemble-partials.scss', /@import\s+"test-partial.scss";\n@import\s+"no-scss";/);
+
+    //     }, 100);
+    //   });
+    // });
   });
 
 });

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -6,326 +6,277 @@ var path = require('path');
 var assert = require('yeoman-generator').assert;
 var helpers = require('yeoman-generator').test;
 var os = require('os');
-// var fs = require('fs');
+var fs = require('fs');
 
 /**
  * Test basic file generation,
  * including that from brei-assemble-structure, and brei-assemble-helpers.
  */
-describe('BREI-APP PROJECT GENERATOR', function(){
-  describe('Main Generator', function () {
-    before(function mainGenerator(done) {
-      helpers.run(path.join(__dirname, '../generators/app'))
-        .inDir(path.join(os.tmpdir(), './temp'))
-        .withOptions({
-          'skip-install': true
+
+describe('Main Generator', function () {
+  before(function mainGenerator(done) {
+    helpers.run(path.join(__dirname, '../generators/app'))
+      .inDir(path.join(os.tmpdir(), './temp'))
+      .withOptions({
+        'skip-install': true
+      })
+      .on('end', done);
+  });
+
+  it('Created Main Files', function () {
+    assert.file([
+      'bower.json',
+      'package.json',
+      '.jshintrc',
+      '.bowerrc',
+      '.gitignore',
+      'Gruntfile.js',
+      'README.md'
+    ]);
+  });
+
+  it('Created Assemble Files', function() {
+    assert.file([
+      'app/assemble/.gitkeep',
+      'app/assemble/README.md',
+      'app/assemble/fixtures/.gitkeep',
+      'app/assemble/helpers/.gitkeep',
+      'app/assemble/home-page.hbs',
+      'app/assemble/index.hbs',
+      'app/assemble/layouts/.gitkeep',
+      'app/assemble/layouts/default.hbs',
+      'app/assemble/layouts/index.hbs',
+      'app/assemble/layouts/module.hbs',
+      'app/assemble/modules/.gitkeep',
+      'app/assemble/partials/.gitkeep'
+    ]);
+  });
+
+  it('Created Helper Files', function() {
+    assert.file([
+      'app/assemble/helpers/README.md',
+      'app/assemble/helpers/helpers.js',
+      'app/assemble/helpers/package.json',
+      'app/assemble/helpers/updateScss.js'
+    ]);
+  });
+
+  it('Created SASS Files', function() {
+    assert.file([
+      'app/sass/README.md',
+      'app/sass/helpers/_access.scss',
+      'app/sass/helpers/_animate.scss',
+      'app/sass/helpers/_common.scss',
+      'app/sass/helpers/_mixins.scss',
+      'app/sass/helpers/_normalize.scss',
+      'app/sass/helpers/_theme-variables.scss',
+      'app/sass/helpers/color-palette/_color-map.scss',
+      'app/sass/helpers/color-palette/_color.scss',
+      'app/sass/helpers/mixins/_layout-mixins.scss',
+      'app/sass/helpers/mixins/_margin.scss',
+      'app/sass/helpers/mixins/_padding.scss',
+      'app/sass/layout/_layout.scss',
+      'app/sass/main.scss',
+      'app/sass/modules/_assemble-modules.scss',
+      'app/sass/modules/_global.scss',
+      'app/sass/package.json',
+      'app/sass/partials/_assemble-partials.scss',
+      'app/sass/print/_default.scss',
+      'app/sass/templates/_assemble-templates.scss'
+    ]);
+  });
+
+  it('Created Grunt Configuration Files', function(){
+    assert.file([
+      'grunt-config/assemble.js',
+      'grunt-config/autoprefixer.js',
+      'grunt-config/clean.js',
+      'grunt-config/compass.js',
+      'grunt-config/concurrent.js',
+      'grunt-config/connect.js',
+      'grunt-config/copy.js',
+      'grunt-config/cssmin.js',
+      'grunt-config/execute.js',
+      'grunt-config/htmlmin.js',
+      'grunt-config/imagemin.js',
+      'grunt-config/jshint.js',
+      'grunt-config/modernizr.js',
+      'grunt-config/open.js',
+      'grunt-config/svgmin.js',
+      'grunt-config/usemin.js',
+      'grunt-config/useminPrepare.js',
+      'grunt-config/watch.js',
+      'grunt-config/yeoman.js'
+    ]);
+  });
+});
+
+describe('Template Sub-Generator', function () {
+  describe('Create new template', function() {
+    before(function template(done) {
+      helpers.run(path.join(__dirname, '../generators/template'))
+        .withPrompt({
+          templateName: 'test template'
         })
         .on('end', done);
     });
 
-    it('Created Main Files', function () {
+    it('Created test-template.hbs and test-template.scss', function() {
       assert.file([
-        'bower.json',
-        'package.json',
-        '.jshintrc',
-        '.bowerrc',
-        '.gitignore',
-        'Gruntfile.js',
-        'README.md'
+        'app/assemble/test-template.hbs',
+        'app/sass/templates/test-template.scss'
       ]);
     });
 
-    it('Created Assemble Files', function() {
-      assert.file([
-        'app/assemble/.gitkeep',
-        'app/assemble/README.md',
-        'app/assemble/fixtures/.gitkeep',
-        'app/assemble/helpers/.gitkeep',
-        'app/assemble/home-page.hbs',
-        'app/assemble/index.hbs',
-        'app/assemble/layouts/.gitkeep',
-        'app/assemble/layouts/default.hbs',
-        'app/assemble/layouts/index.hbs',
-        'app/assemble/layouts/module.hbs',
-        'app/assemble/modules/.gitkeep',
-        'app/assemble/partials/.gitkeep'
-      ]);
-    });
-
-    it('Created Helper Files', function() {
-      assert.file([
-        'app/assemble/helpers/README.md',
-        'app/assemble/helpers/helpers.js',
-        'app/assemble/helpers/package.json',
-        'app/assemble/helpers/updateScss.js'
-      ]);
-    });
-
-    it('Created SASS Files', function() {
-      assert.file([
-        'app/sass/README.md',
-        'app/sass/helpers/_access.scss',
-        'app/sass/helpers/_animate.scss',
-        'app/sass/helpers/_common.scss',
-        'app/sass/helpers/_mixins.scss',
-        'app/sass/helpers/_normalize.scss',
-        'app/sass/helpers/_theme-variables.scss',
-        'app/sass/helpers/color-palette/_color-map.scss',
-        'app/sass/helpers/color-palette/_color.scss',
-        'app/sass/helpers/mixins/_layout-mixins.scss',
-        'app/sass/helpers/mixins/_margin.scss',
-        'app/sass/helpers/mixins/_padding.scss',
-        'app/sass/layout/_layout.scss',
-        'app/sass/main.scss',
-        'app/sass/modules/_assemble-modules.scss',
-        'app/sass/modules/_global.scss',
-        'app/sass/package.json',
-        'app/sass/partials/_assemble-partials.scss',
-        'app/sass/print/_default.scss',
-        'app/sass/templates/_assemble-templates.scss'
-      ]);
-    });
-
-    it('Created Grunt Configuration Files', function(){
-      assert.file([
-        'grunt-config/assemble.js',
-        'grunt-config/autoprefixer.js',
-        'grunt-config/clean.js',
-        'grunt-config/compass.js',
-        'grunt-config/concurrent.js',
-        'grunt-config/connect.js',
-        'grunt-config/copy.js',
-        'grunt-config/cssmin.js',
-        'grunt-config/execute.js',
-        'grunt-config/htmlmin.js',
-        'grunt-config/imagemin.js',
-        'grunt-config/jshint.js',
-        'grunt-config/modernizr.js',
-        'grunt-config/open.js',
-        'grunt-config/svgmin.js',
-        'grunt-config/usemin.js',
-        'grunt-config/useminPrepare.js',
-        'grunt-config/watch.js',
-        'grunt-config/yeoman.js'
+    it('Test-template .hbs && .scss have the right content', function() {
+      assert.fileContent([
+        ['app/assemble/test-template.hbs', /title\:\stest-template|\s+test-template/],
+        ['app/sass/templates/test-template.scss', /\.test-template {\n\s+\/\/ Awesome styles\n}/]
       ]);
     });
   });
-
-  describe('Template Sub-Generator', function () {
-    describe('Create new template', function() {
-      before(function template(done) {
-        helpers.run(path.join(__dirname, '../generators/template'))
-          .withPrompt({
-            templateName: 'test template'
-          })
-          .on('end', done);
-      });
-
-      it('Created test-template.hbs and test-template.scss', function() {
-        assert.file([
-          'app/assemble/test-template.hbs',
-          'app/sass/templates/test-template.scss'
-        ]);
-      });
-
-      it('Test-template .hbs && .scss have the right content', function() {
-        assert.fileContent([
-          ['app/assemble/test-template.hbs', /title\:\stest-template|\s+test-template/],
-          ['app/sass/templates/test-template.scss', /\.test-template {\n\s+\/\/ Awesome styles\n}/]
-        ]);
-      });
-    });
-
-    // describe('Test updateScss.js', function() {
-    //   it('Created no-scss.scss', function() {
-    //     fs.writeFileSync('app/assemble/no-scss.hbs', 'no-scss');
-    //     setTimeout(function() {
-    //       assert.file([
-    //         'app/assemble/no-scss.hbs',
-    //         'app/sass/templates/_no-scss.scss'
-    //       ]);
-
-    //       assert.fileContent('app/sass/templates/_assemble-templates.scss', /@import\s+"home-page";\n@import\s+"test-template.scss";\n@import\s+"no-scss";/);
-
-    //     }, 100);
-    //   });
-    // });
-  });
-
-  describe('Module Sub-Generator', function () {
-    describe('Create new module', function() {
-      before(function module(done) {
-        helpers.run(path.join(__dirname, '../generators/module'))
-          .withPrompt({
-            moduleName: 'test module'
-          })
-          .on('end', done);
-      });
-
-      it('Created _test-module.hbs and _test-module.scss', function() {
-        assert.file([
-          'app/assemble/modules/_test-module.hbs',
-          'app/sass/modules/_test-module.scss'
-        ]);
-      });
-
-      it('Test-module .hbs && .scss have the right content', function() {
-        assert.fileContent([
-          ['app/assemble/modules/_test-module.hbs', /title\:\stest-module|\s+test-module/],
-          ['app/sass/modules/_test-module.scss', /\.test-module {\n\s+\/\/\sAwesome styles\n}/]
-        ]);
-      });
-    });
-
-    // describe('Test updateScss.js', function() {
-    //   it('Created no-scss.scss', function() {
-    //     fs.writeFileSync('app/assemble/modules/_no-scss.hbs', 'no-scss');
-    //     setTimeout(function() {
-    //       assert.file([
-    //         'app/assemble/modules/_no-scss.hbs',
-    //         'app/sass/modules/_no-scss.scss'
-    //       ]);
-
-    //       assert.fileContent('app/sass/modules/_assemble-modules.scss', /@import\s+"test-module.scss";\n@import\s+"no-scss";/);
-
-    //     }, 100);
-    //   });
-    // });
-  });
-
-  describe('Partial Sub-Generator', function () {
-    describe('Create new partial', function() {
-      before(function partial(done) {
-        helpers.run(path.join(__dirname, '../generators/partial'))
-          .withPrompt({
-            partialName: 'test partial'
-          })
-          .on('end', done);
-      });
-
-      it('Created test-partial.hbs and _test-partial.scss', function() {
-        assert.file([
-          'app/assemble/partials/test-partial.hbs',
-          'app/sass/partials/_test-partial.scss'
-        ]);
-      });
-
-      it('Test-partial .hbs && .scss have the right content', function() {
-        assert.fileContent([
-          ['app/assemble/partials/test-partial.hbs', /title\:\stest-partial|\s+test-partial/],
-          ['app/sass/partials/_test-partial.scss', /\.test-partial {\n\s+\/\/\sAwesome styles\n}/]
-        ]);
-      });
-    });
-
-    // describe('Test updateScss.js', function() {
-    //   it('Created no-scss.scss', function() {
-    //     fs.writeFileSync('app/assemble/partials/_no-scss.hbs', 'no-scss');
-    //     setTimeout(function() {
-    //       assert.file([
-    //         'app/assemble/partials/no-scss.hbs',
-    //         'app/sass/partials/_no-scss.scss'
-    //       ]);
-
-    //       assert.fileContent('app/sass/partials/_assemble-partials.scss', /@import\s+"test-partial.scss";\n@import\s+"no-scss";/);
-
-    //     }, 100);
-    //   });
-    // });
-  });
-
-  describe('Pattern Library Sub-Generator', function () {
-    describe('Import Partial Pattern', function() {
-      before(function partialPattern(done) {
-        helpers.run(path.join(__dirname, '../generators/pattern'))
-          .withPrompt({
-            type: 'partials',
-            name: 'test pattern partial'
-          })
-          .on('end', done);
-      });
-
-      it('Created test-partial.hbs and _test-partial.scss', function() {
-        assert.file([
-          'app/assemble/partials/test-partial.hbs',
-          'app/sass/partials/_test-partial.scss'
-        ]);
-      });
-
-      it('Test-pattern-partial .hbs && .scss have the right content', function() {
-        assert.fileContent([
-          ['app/assemble/partials/test-pattern-partial.hbs', /test-pattern-partial/],
-          ['app/sass/partials/_test-pattern-partial.scss', /\.test-pattern-partial {\n\s+\/\/\sAwesome styles\n}/]
-        ]);
-      });
-    });
-
-    describe('Import Module Pattern', function() {
-      before(function modulePattern(done) {
-        helpers.run(path.join(__dirname, '../generators/pattern'))
-          .withPrompt({
-            type: 'modules',
-            name: 'test pattern module'
-          })
-          .on('end', done);
-      });
-
-      it('Created test-pattern-modules.hbs and _test-pattern-modules.scss', function() {
-        assert.file([
-          'app/assemble/moduless/test-pattern-modules.hbs',
-          'app/sass/moduless/_test-pattern-modules.scss'
-        ]);
-      });
-
-      it('Test-pattern-modules .hbs && .scss have the right content', function() {
-        assert.fileContent([
-          ['app/assemble/moduless/test-pattern-modules.hbs', /title\:\stest-pattern-modules|\s+test-pattern-modules/],
-          ['app/sass/moduless/_test-pattern-modules.scss', /\.test-pattern-modules {\n\s+\/\/\sAwesome styles\n}/]
-        ]);
-      });
-    });
-
-    describe('Import Template Pattern', function() {
-      before(function templatePattern(done) {
-        helpers.run(path.join(__dirname, '../generators/pattern'))
-          .withPrompt({
-            type: 'template',
-            name: 'test pattern template'
-          })
-          .on('end', done);
-      });
-
-      it('Created test-pattern-template.hbs and _test-pattern-template.scss', function() {
-        assert.file([
-          'app/assemble/templates/test-pattern-template.hbs',
-          'app/sass/templates/_test-pattern-template.scss'
-        ]);
-      });
-
-      it('Test-pattern-template .hbs && .scss have the right content', function() {
-        assert.fileContent([
-          ['app/assemble/templates/test-pattern-template.hbs', /title\:\stest-pattern-template|\s+test-pattern-template/],
-          ['app/sass/templates/_test-pattern-template.scss', /\.test-pattern-template {\n\s+\/\/\sAwesome styles\n}/]
-        ]);
-      });
-    });
-
-    // describe('Test updateScss.js', function() {
-    //   it('Created no-scss.scss', function() {
-    //     fs.writeFileSync('app/assemble/partials/no-scss.hbs', 'no-scss');
-    //     setTimeout(function() {
-    //       assert.file([
-    //         'app/assemble/partials/no-scss.hbs',
-    //         'app/sass/partials/_no-scss.scss'
-    //       ]);
-
-    //       assert.fileContent('app/sass/partials/_assemble-partials.scss', /@import\s+"test-partial.scss";\n@import\s+"no-scss";/);
-
-    //     }, 100);
-    //   });
-    // });
-  });
-
 });
 
+describe('Module Sub-Generator - ', function () {
+  describe('Create new module', function() {
+    before(function module(done) {
+      helpers.run(path.join(__dirname, '../generators/module'))
+        .withPrompt({
+          moduleName: 'test module'
+        })
+        .on('end', done);
+    });
 
+    it('Created _test-module.hbs and _test-module.scss', function() {
+      assert.file([
+        'app/assemble/modules/_test-module.hbs',
+        'app/sass/modules/_test-module.scss'
+      ]);
+    });
+
+    it('Test-module .hbs && .scss have the right content', function() {
+      assert.fileContent([
+        ['app/assemble/modules/_test-module.hbs', /title\:\stest-module|\s+test-module/],
+        ['app/sass/modules/_test-module.scss', /\.test-module {\n\s+\/\/\sAwesome styles\n}/]
+      ]);
+    });
+  });
+});
+
+describe('Partial Sub-Generator - ', function () {
+  describe('Create new partial', function() {
+    before(function partial(done) {
+      helpers.run(path.join(__dirname, '../generators/partial'))
+        .withPrompt({
+          partialName: 'test partial'
+        })
+        .on('end', done);
+    });
+
+    it('Created test-partial.hbs and _test-partial.scss', function() {
+      assert.file([
+        'app/assemble/partials/test-partial.hbs',
+        'app/sass/partials/_test-partial.scss'
+      ]);
+    });
+
+    it('Test-partial .hbs && .scss have the right content', function() {
+      assert.fileContent([
+        ['app/assemble/partials/test-partial.hbs', /title\:\stest-partial|\s+test-partial/],
+        ['app/sass/partials/_test-partial.scss', /\.test-partial {\n\s+\/\/\sAwesome styles\n}/]
+      ]);
+    });
+  });
+});
+
+describe('Pattern Library Sub-Generator - ', function () {
+  describe('Import Partial Pattern', function() {
+    before(function partialPattern(done) {
+      helpers.run(path.join(__dirname, '../generators/pattern'))
+        .withPrompt({
+          type: 'partials',
+          name: 'test pattern partial'
+        })
+        .on('end', done);
+    });
+
+    it('Created test-partial.hbs and _test-partial.scss - ', function() {
+      assert.file([
+        'app/assemble/partials/test-pattern-partial.hbs',
+        'app/sass/partials/_test-pattern-partial.scss'
+      ]);
+    });
+
+    it('Test-pattern-partial .hbs && .scss have the right content - ', function() {
+      assert.fileContent([
+        ['app/assemble/partials/test-pattern-partial.hbs', /class\="test-pattern-partial"/g],
+        ['app/sass/partials/_test-pattern-partial.scss', /\.test-pattern-partial/g]
+      ]);
+    });
+  });
+
+  describe('Import Module Pattern - ', function() {
+    before(function modulePattern(done) {
+      helpers.run(path.join(__dirname, '../generators/pattern'))
+        .withPrompt({
+          type: 'modules',
+          name: 'test pattern module'
+        })
+        .on('end', done);
+    });
+
+    it('Created test-pattern-module.hbs and _test-pattern-module.scss - ', function() {
+      assert.file([
+        'app/assemble/modules/_test-pattern-module.hbs',
+        'app/sass/modules/_test-pattern-module.scss'
+      ]);
+    });
+
+    it('Test-pattern-modules .hbs && .scss have the right content - ', function() {
+      assert.fileContent([
+        ['app/assemble/modules/_test-pattern-module.hbs', /title\:\s"test-pattern-module"/g],
+        ['app/sass/modules/_test-pattern-module.scss', /\.test-pattern-module/g]
+      ]);
+    });
+  });
+
+  describe('Import Template Pattern', function() {
+    before(function templatePattern(done) {
+      helpers.run(path.join(__dirname, '../generators/pattern'))
+        .withPrompt({
+          type: 'template',
+          name: 'test pattern template'
+        })
+        .on('end', done);
+    });
+
+    it('Created test-pattern-template.hbs and _test-pattern-template.scss', function() {
+      assert.file([
+        'app/assemble/test-pattern-template.hbs',
+        'app/sass/templates/_test-pattern-template.scss'
+      ]);
+    });
+
+    it('Test-pattern-template .hbs && .scss have the right content', function() {
+      assert.fileContent([
+        ['app/assemble/test-pattern-template.hbs', /title\:\sTest\sPattern\sTemplate/g],
+        ['app/sass/templates/_test-pattern-template.scss', /\.test-pattern-template/g]
+      ]);
+    });
+  });
+});
+
+describe('Test updateScss.js', function() {
+  it('Created no-scss.scss', function() {
+    fs.writeFile('app/assemble/no-scss.hbs', 'no-scss', function(err) {
+      if (err) { throw err; }
+
+      assert.file([
+        'app/assemble/no-scss.hbs',
+        'app/sass/templates/_no-scss.scss'
+      ]);
+
+      assert.fileContent('app/sass/templates/_assemble-templates.scss', /@import\s+"home-page";\n@import\s+"test-template.scss";\n@import\s+"no-scss";/);
+    });
+  });
+});


### PR DESCRIPTION
This is the initial iteration of the Pattern Library Integration. 

A pattern first has to be in the library to be used.

```bash
yo brei-app:pattern
```
You can add the module `basic-footer`.

It'll need some better error handling and the prompting should be changed to more of a radio button setup, but for now, this will get us going.

fixes https://github.com/BarkleyREI/generator-brei-app/issues/48